### PR TITLE
Extract recipients error handling

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -36,51 +36,40 @@ function extractRecipient(recipient) {
         return { err: new Error("Please specify only one recipient key at a time.") };
     }
 
-    // Group the possible recipient keys by their object type
-    var validRecipientKeys = {
-        String: [
-            'topic',
-            'notificationKey'
-        ],
-        Array: [
-            'registrationIds',
-            'registrationTokens'
-        ]
-    };
-    
-    var theRecipient;
-    
-    for (var type in validRecipientKeys) {
-        for (var i in validRecipientKeys[type]) {
-            var key = validRecipientKeys[type][i];
-            
-            if (recipient[key]) {
-                // Type validation
-                if ((type == 'String' && typeof recipient[key] != "string") 
-                    || (type == 'Array' && !Array.isArray(recipient[key]))) {
-                    return { err: new Error("Recipient key '" + key + "' should be provided as '" + type + "'.") };
-                }
-                
-                // Avoid multiple recipient keys
-                if (theRecipient) {
-                    return { err: new Error("Please specify only one recipient key at a time.") };
-                }
-                
-                theRecipient = recipient[key];
-            }
-        }
+    var key = recipientKeys[0];
+    var value  = recipient[key];
+
+    if(!value) {
+        return { err: new Error("Falsy value for recipient key '" + key + "'.") };
     }
-    
-    if (!theRecipient) {
-        return { 
-            err: new Error("Failed to extract recipient from '" + Object.keys(recipient) + "'. Valid keys: '" + validRecipientKeys['String'].join(', ') + ', ' + validRecipientKeys['Array'].join(', ') + "'.") 
-        };
+
+    var keyValidators = {
+        topic: isString,
+        notificationKey: isString,
+        registrationIds: isArray,
+        registrationTokens: isArray
+    };
+
+    var validator = keyValidators[key];
+    if(!validator) {
+        return { err: new Error("Key '" + key + "' is not a valid recipient key.") };
+    }
+    if(!validator(value)) {
+        return { err: new Error("Recipient key '" + key + "' was provided as an incorrect type.") };
     }
 
     return {
         err: null,
-        recipient: theRecipient
+        recipient: value
     };
+}
+
+function isString(x) {
+    return typeof x == "string";
+}
+
+function isArray(x) {
+    return Array.isArray(x);
 }
 
 Sender.prototype.sendNoRetry = function(message, recipient, callback) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -29,6 +29,9 @@ var parseAndRespond = function(resBody, callback) {
 function extractRecipient(recipient) {
     var recipientKeys = Object.keys(recipient);
 
+    if(recipientKeys.length < 1) {
+        return { err: new Error("Please specify a recipient key (empty object provided).") };
+    }
     if(recipientKeys.length > 1) {
         return { err: new Error("Please specify only one recipient key at a time.") };
     }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,6 +27,10 @@ var parseAndRespond = function(resBody, callback) {
 };
 
 function extractRecipient(recipient) {
+    if(Object.keys(recipient).length > 1) {
+        return { err: new Error("Please specify only one recipient key at a time.") };
+    }
+
     // Group the possible recipient keys by their object type
     var validRecipientKeys = {
         String: [

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,7 +27,9 @@ var parseAndRespond = function(resBody, callback) {
 };
 
 function extractRecipient(recipient) {
-    if(Object.keys(recipient).length > 1) {
+    var recipientKeys = Object.keys(recipient);
+
+    if(recipientKeys.length > 1) {
         return { err: new Error("Please specify only one recipient key at a time.") };
     }
 


### PR DESCRIPTION
As promised. Note that this PR merges into `eladnava/extract-recipients-error-handling`.

The tests still pass, and the `extractRecipient` code is now linear.